### PR TITLE
Sign Assertion if WantAssertionsSigned is true

### DIFF
--- a/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/ServiceProviderConfig.java
+++ b/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/ServiceProviderConfig.java
@@ -58,6 +58,7 @@ public class ServiceProviderConfig
       rsp.setAssertionConsumerURL(checkMeta.getPostEndpoint());
       rsp.setEncryptionCert(checkMeta.getEncCert());
       rsp.setSignatureCert(checkMeta.getSigCert());
+      rsp.setSignAssertions(checkMeta.wantSignedAssertions());
       firstProvider = rsp;
     }
     catch (IOException | CertificateException | XMLParserException | UnmarshallingException

--- a/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/eid/RequestingServiceProvider.java
+++ b/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/eid/RequestingServiceProvider.java
@@ -24,6 +24,8 @@ public class RequestingServiceProvider
 
   private X509Certificate encryptionCert = null;
 
+  private Boolean signAssertions = false;
+
   public RequestingServiceProvider(String entityID)
   {
     this.entityID = entityID;
@@ -62,5 +64,13 @@ public class RequestingServiceProvider
   public X509Certificate getEncryptionCert()
   {
     return encryptionCert;
+  }
+
+  public Boolean wantSignedAssertions() {
+    return signAssertions;
+  }
+
+  public void setSignAssertions(Boolean signAssertions) {
+    this.signAssertions = signAssertions;
   }
 }

--- a/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/servlet/ResponseSender.java
+++ b/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/servlet/ResponseSender.java
@@ -436,7 +436,8 @@ public class ResponseSender extends HttpServlet
                                                 EidasLoA.HIGH,
                                                 samlReqSession.getReqId(),
                                                 encrypter,
-                                                signer);
+                                                signer,
+                                                reqSP.wantSignedAssertions());
     String content = WebServiceHelper.createForwardToConsumer(eidasResp, reqRelayState, null);
 
     HttpServerUtils.setPostContent(content, reqSP.getAssertionConsumerURL(), null, resp);

--- a/eidas-middleware/src/test/java/de/governikus/eumw/eidasmiddleware/EidasRoundTrip.java
+++ b/eidas-middleware/src/test/java/de/governikus/eumw/eidasmiddleware/EidasRoundTrip.java
@@ -151,7 +151,8 @@ public class EidasRoundTrip
                                           EidasLoA.LOW,
                                           "_inresp",
                                           new EidasEncrypter(true, keyPair2.getCert()),
-                                          signer);
+                                          signer,
+                                          false);
         s = new String(result, StandardCharsets.UTF_8);
         Assert.assertTrue(s != null);
         try (ByteArrayInputStream is = new ByteArrayInputStream(result))

--- a/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasMetadataNode.java
+++ b/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasMetadataNode.java
@@ -88,6 +88,8 @@ public class EidasMetadataNode
 
   private List<EidasNameIdType> supportedNameIdTypes = new ArrayList<>();
 
+  private Boolean signAssertions = false;
+
   private EidasMetadataNode()
   {
     super();
@@ -229,6 +231,14 @@ public class EidasMetadataNode
     this.spType = spType;
   }
 
+  public Boolean wantSignedAssertions() {
+    return signAssertions;
+  }
+
+  public void setSignAssertions(Boolean signAssertions) {
+    this.signAssertions = signAssertions;
+  }
+
   /**
    * Creates a metadata.xml as byte array
    * 
@@ -276,6 +286,7 @@ public class EidasMetadataNode
     template = template.replace("$supPersonTel", supportcontact.getTel());
     template = template.replace("$POST_ENDPOINT", postEndpoint);
     template = template.replace("$SPType", spType.value);
+    template = template.replace("$signAssertions", signAssertions.toString());
 
 
 
@@ -378,6 +389,8 @@ public class EidasMetadataNode
         eidasMetadataService.setPostEndpoint(s.getLocation());
       }
     });
+
+    eidasMetadataService.setSignAssertions(ssoDescriptor.getWantAssertionsSigned());
 
     for ( KeyDescriptor k : ssoDescriptor.getKeyDescriptors() )
     {

--- a/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasResponse.java
+++ b/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasResponse.java
@@ -242,7 +242,14 @@ public class EidasResponse
     return returnValue;
   }
 
-  byte[] generate() throws XMLParserException, IOException, UnmarshallingException,
+  byte[] generate() throws IOException, CertificateEncodingException, TransformerException,
+      EncryptionException, UnmarshallingException, MarshallingException, ComponentInitializationException,
+      XMLParserException, SignatureException
+  {
+    return generate(false);
+  }
+
+  byte[] generate(boolean signAssertion) throws XMLParserException, IOException, UnmarshallingException,
     CertificateEncodingException, EncryptionException, MarshallingException, SignatureException,
     TransformerFactoryConfigurationError, TransformerException, ComponentInitializationException
   {
@@ -278,7 +285,7 @@ public class EidasResponse
     assoTemp = assoTemp.replace("$Destination", destination);
 
     String generatedAssertionXML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + assoTemp;
-    Assertion ass = null;
+    Assertion ass;
     BasicParserPool ppMgr = Utils.getBasicParserPool();
     try (InputStream is = new ByteArrayInputStream(generatedAssertionXML.getBytes(StandardCharsets.UTF_8)))
     {
@@ -288,6 +295,23 @@ public class EidasResponse
       UnmarshallerFactory unmarshallerFactory = XMLObjectProviderRegistrySupport.getUnmarshallerFactory();
       Unmarshaller unmarshaller = unmarshallerFactory.getUnmarshaller(metadataRoot);
       ass = (Assertion)unmarshaller.unmarshall(metadataRoot);
+    }
+
+    if (signAssertion) {
+      Marshaller assMarshaller = XMLObjectProviderRegistrySupport.getMarshallerFactory()
+          .getMarshaller(ass.getElementQName());
+
+      XMLSignatureHandler.addSignature(ass,
+          signer.getSigKey(),
+          signer.getSigCert(),
+          signer.getSigType(),
+          signer.getSigDigestAlg());
+
+      assMarshaller.marshall(ass);
+
+      if (ass.getSignature() != null) {
+        Signer.signObject(ass.getSignature());
+      }
     }
 
     Assertion[] assertions = new Assertion[]{ass};

--- a/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasSaml.java
+++ b/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasSaml.java
@@ -285,7 +285,8 @@ public class EidasSaml
                                       EidasLoA loa,
                                       String inResponseTo,
                                       EidasEncrypter encrypter,
-                                      EidasSigner signer)
+                                      EidasSigner signer,
+                                      Boolean signAssertion)
     throws InitializationException, CertificateEncodingException, XMLParserException, IOException,
     UnmarshallingException, EncryptionException, MarshallingException, SignatureException,
     TransformerFactoryConfigurationError, TransformerException, ComponentInitializationException
@@ -293,7 +294,7 @@ public class EidasSaml
     init();
     EidasResponse response = new EidasResponse(att, destination, recipient, nameid, inResponseTo, issuer, loa,
                                                signer, encrypter);
-    return response.generate();
+    return response.generate(signAssertion);
   }
 
   /**

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/metadata_nodes_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/metadata_nodes_template.xml
@@ -7,7 +7,7 @@
                 <alg:SigningMethod MinKeySize="256" Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256"/>
                 <alg:SigningMethod MinKeySize="3072" MaxKeySize="4096"  Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>                
             </md:Extensions>
-      <md:SPSSODescriptor AuthnRequestsSigned="true" WantAssertionsSigned="false"
+      <md:SPSSODescriptor AuthnRequestsSigned="true" WantAssertionsSigned="$signAssertions"
             protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
             <md:KeyDescriptor use="signing">
                 <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">

--- a/eidas-starterkit/src/test/java/de/governikus/eumw/eidasstarterkit/TestEidasSaml.java
+++ b/eidas-starterkit/src/test/java/de/governikus/eumw/eidasstarterkit/TestEidasSaml.java
@@ -11,6 +11,9 @@
 package de.governikus.eumw.eidasstarterkit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -42,6 +45,7 @@ import org.opensaml.core.config.InitializationException;
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.core.xml.io.UnmarshallingException;
 import org.opensaml.xmlsec.encryption.support.EncryptionException;
+import org.opensaml.xmlsec.signature.Signature;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.xml.sax.SAXException;
 
@@ -231,7 +235,8 @@ public class TestEidasSaml
                                                loa,
                                                inResponseTo,
                                                encrypter,
-                                               signer);
+                                               signer,
+                                               false);
     System.out.println("-->>Response-->>" + new String(response));
 
     EidasResponse result = EidasResponse.parse(new ByteArrayInputStream(response), keypair, cert);
@@ -240,12 +245,33 @@ public class TestEidasSaml
     assertEquals(result.getNameId().getValue(), nameid.getValue());
     assertEquals(result.getIssuer(), issuer);
     assertEquals(result.getInResponseTo(), inResponseTo);
+    assertNull(result.getOpenSamlResponse().getAssertions().get(0).getSignature());
     for ( int i = 0 ; i < att.size() ; i++ )
     {
       assertEquals(result.getAttributes().get(i).getLatinScript().replaceAll("\\s+", ""),
                    att.get(i).getLatinScript().replaceAll("\\s+", ""));
     }
 
+    byte[] signedAssResponse = EidasSaml.createResponse(att,
+        destination,
+        recipient,
+        nameid,
+        issuer,
+        loa,
+        inResponseTo,
+        encrypter,
+        signer,
+        true);
+    System.out.println("-->>Response-->>" + new String(response));
+
+    EidasResponse signedAssResult = EidasResponse.parse(new ByteArrayInputStream(signedAssResponse), keypair, cert);
+    Signature signature = signedAssResult.getOpenSamlResponse().getAssertions().get(0).getSignature();
+    assertNotNull(signature);
+
+    String signatureCertValue = signature.getKeyInfo().getX509Datas().get(0).getX509Certificates().get(0).getValue();
+    String pemSignatureCert = "-----BEGIN CERTIFICATE-----\n" + Utils.breakAfter76Chars(signatureCertValue) + "\n-----END CERTIFICATE-----";
+    X509Certificate actualSignatureCert = Utils.readCert(pemSignatureCert.getBytes());
+    assertEquals(actualSignatureCert, cert[0]);
   }
 
   @Test


### PR DESCRIPTION
If the requesting service has the `WantAssertionsSigned` attribute set
to true in the `SPSSODescriptor` of their metadata, then sign the
`Assertion` sent back in the middleware's `Response`.